### PR TITLE
[WIP] Cache data in redis

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ to render screenshots of [Webmaker][] makes on-the-fly.
 * Node v0.10
 * A free Blitline account
 * An Amazon S3 bucket
+* Redis 2.6 or later
 
 You can get a Blitline account either through their website, or via
 a free [Heroku add-on][].
@@ -59,6 +60,13 @@ embedding screenshots of Webmaker makes in a [Discourse][] forum.
 If your S3 bucket is hosted at a custom domain, you can optionally
 set `S3_WEBSITE` to its origin followed by a `/`, e.g.
 `http://my-webmaker-screenshots.com/`.
+
+If your redis instance isn't at the default of port 6379 on localhost,
+you can define `REDIS_URL` to point at it. Use the form
+`redis://:password@hostname:port`.
+
+`REDISTOGO_URL` is a synonym for `REDIS_URL`, to make deployment on
+Heroku easier.
 
   [Blitline]: http://blitline.com/
   [Webmaker]: https://webmaker.org/

--- a/app.js
+++ b/app.js
@@ -1,7 +1,9 @@
 var request = require('request');
 var express = require('express');
 var bodyParser = require('body-parser');
+var redis = require('redis');
 
+var RedisCache = require('./redis-cache');
 var keys = require('./keys');
 var makes = require('./makes');
 var blitline = require('./blitline');
@@ -19,6 +21,7 @@ if (!BLITLINE_APPLICATION_ID)
 if (!S3_BUCKET)
   throw new Error('S3_BUCKET must be defined');
 
+var redisCache = new RedisCache(redis.createClient());
 var app = express();
 
 app.use(bodyParser.json());
@@ -46,7 +49,11 @@ app.post('/', function(req, res, next) {
       }
     }, function(err) {
       if (err) return next(err);
-      return res.send({screenshot: S3_WEBSITE + key});
+      var url = S3_WEBSITE + key;
+      redisCache.set(key, {status: 302, url: url}, function(err) {
+        if (err) return next(err);
+        return res.send({screenshot: url});
+      });
     });
   });
 });
@@ -56,32 +63,43 @@ app.use(function(req, res, next) {
   if (!(req.method == 'GET' && keys.isWellFormed(key)))
     return next();
 
-  var s3url = S3_WEBSITE + key;
+  redisCache.get(key, function cache(cb) {
+    var s3url = S3_WEBSITE + key;
 
-  request.head(s3url, function(err, s3res) {
-    if (err) return next(err);
-    if (s3res.statusCode == 200)
-      return res.redirect(s3url);
+    request.head(s3url, function(err, s3res) {
+      if (err) return cb(err);
+      if (s3res.statusCode == 200)
+        return cb(null, {status: 302, url: s3url});
 
-    var makeUrl = keys.toMakeUrl(key);
+      var makeUrl = keys.toMakeUrl(key);
 
-    makes.verifyIsHtml(makeUrl, function(err, isHtml) {
-      if (err) return next(err);
-      if (!isHtml) return next();
+      makes.verifyIsHtml(makeUrl, function(err, isHtml) {
+        if (err) return cb(err);
+        if (!isHtml) return cb(null, {
+          status: 404,
+          reason: 'URL is not HTML'
+        });
 
-      blitline.screenshot({
-        appId: BLITLINE_APPLICATION_ID,
-        url: makeUrl,
-        wait: DEFAULT_WAIT,
-        s3: {
-          bucket: S3_BUCKET,
-          key: key
-        }
-      }, function(err) {
-        if (err) return next(err);
-        return res.redirect(s3url);
+        blitline.screenshot({
+          appId: BLITLINE_APPLICATION_ID,
+          url: makeUrl,
+          wait: DEFAULT_WAIT,
+          s3: {
+            bucket: S3_BUCKET,
+            key: key
+          }
+        }, function(err) {
+          if (err) return cb(err);
+          return cb(null, {status: 302, url: s3url});
+        });
       });
     });
+  }, function done(err, info) {
+    if (err) return next(err);
+    if (info.status == 404) return next();
+    if (info.status == 302)
+      return res.redirect(info.url);
+    return next(new Error("invalid status: " + info.status));
   });
 });
 

--- a/app.js
+++ b/app.js
@@ -1,7 +1,6 @@
 var request = require('request');
 var express = require('express');
 var bodyParser = require('body-parser');
-var redis = require('redis');
 
 var RedisCache = require('./redis-cache');
 var keys = require('./keys');
@@ -21,7 +20,8 @@ if (!BLITLINE_APPLICATION_ID)
 if (!S3_BUCKET)
   throw new Error('S3_BUCKET must be defined');
 
-var redisCache = new RedisCache(redis.createClient());
+var redisCache = new RedisCache(process.env.REDIS_URL ||
+                                process.env.REDISTOGO_URL);
 var app = express();
 
 app.use(bodyParser.json());

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Take thumbnail screenshots of Webmaker makes.",
   "dependencies": {
     "body-parser": "~1.2.0",
+    "redis": "0.12.1",
     "express": "~4.2.0",
     "request": "2.34.0"
   },

--- a/redis-cache.js
+++ b/redis-cache.js
@@ -1,3 +1,6 @@
+var redis = require('redis');
+var urlParse = require("url").parse;
+
 var LOCK_EXPIRY_IN_SECONDS = 10;
 var UNLOCK_WAIT_MS = 500;
 var RELEASE_LOCK_SCRIPT = [
@@ -9,7 +12,20 @@ var RELEASE_LOCK_SCRIPT = [
   'end'
 ].join('\n');
 
+function clientFromURL(url) {
+  var urlInfo = urlParse(url);
+  var client = redis.createClient(urlInfo.port, urlInfo.hostname);
+  if (urlInfo.auth)
+    client.auth(urlInfo.auth.split(":")[1]);
+  return client;
+}
+
 function RedisCache(client) {
+  if (!client) {
+    client = redis.createClient();
+  } else if (typeof(client) == 'string') {
+    client = clientFromURL(client);
+  }
   this.client = client;
 }
 

--- a/redis-cache.js
+++ b/redis-cache.js
@@ -1,0 +1,66 @@
+var LOCK_EXPIRY_IN_SECONDS = 10;
+var UNLOCK_WAIT_MS = 500;
+var RELEASE_LOCK_SCRIPT = [
+  'if redis.call("get",KEYS[1]) == ARGV[1]',
+  'then',
+  '  return redis.call("del",KEYS[1])',
+  'else',
+  '  return 0',
+  'end'
+].join('\n');
+
+function RedisCache(client) {
+  this.client = client;
+}
+
+RedisCache.prototype = {
+  get: function(url, cacheCb, doneCb) {
+    var self = this;
+    var infoKey = "info_" + url;
+
+    self.client.get(infoKey, function(err, info) {
+      if (err) return doneCb(err);
+      if (info) {
+        try {
+          info = JSON.parse(info);
+        } catch (e) {
+          return doneCb(e);
+        }
+        return doneCb(null, info);
+      } else {
+        var lockToken = Math.random().toString();
+        var lockKey = "lock_" + url;
+        self.client.set([
+          lockKey, lockToken, "NX", "EX",
+          LOCK_EXPIRY_IN_SECONDS.toString()
+        ], function(err, result) {
+          if (err) return doneCb(e);
+          if (result === null) {
+            setTimeout(function() {
+              self.get(url, cacheCb, doneCb);
+            }, UNLOCK_WAIT_MS);
+          } else {
+            cacheCb(function(err, info) {
+              if (err) {
+                // TODO: Be nice and release our lock.
+                return doneCb(err);
+              }
+              self.client.multi()
+                .set(infoKey, JSON.stringify(info))
+                .eval(RELEASE_LOCK_SCRIPT, "1", lockKey, lockToken)
+                .exec(function(err, results) {
+                  if (err) {
+                    // TODO: Be nice and release our lock.
+                    return doneCb(err);
+                  }
+                  doneCb(null, info);
+                });
+            });
+          }
+        });
+      }
+    });
+  }
+};
+
+module.exports = RedisCache;

--- a/redis-cache.js
+++ b/redis-cache.js
@@ -14,9 +14,15 @@ function RedisCache(client) {
 }
 
 RedisCache.prototype = {
+  _getInfoKey: function(url) {
+    return "info_" + url
+  },
+  set: function(url, info, cb) {
+    this.client.set(this._getInfoKey(url), JSON.stringify(info), cb);
+  },
   get: function(url, cacheCb, doneCb) {
     var self = this;
-    var infoKey = "info_" + url;
+    var infoKey = self._getInfoKey(url);
 
     self.client.get(infoKey, function(err, info) {
       if (err) return doneCb(err);


### PR DESCRIPTION
Currently, the way we're preventing multiple identical jobs from being submitted to Blitline is by keeping an in-process cache of all clients waiting to be notified about the screenshot. As the existing comments mention, this doesn't scale.

To make it scale, I'm proposing that we use redis to not only block multiple requests from submitting identical Blitline jobs, but also to cache response information in general. This means that e.g. we won't have to issue a `HEAD` request to S3 every time an image is requested, as that information will be in redis instead.

So, the following procedure should be followed whenever a request for a screenshot is made:

1. See if we have information about the make in redis. if so, return either a 404 if the make doesn't exist, or a redirect to the screenshot on S3 if it does. If we *don't* have any cached information in redis, go to step 2.
2. Obtain a redis lock w/ an expiry of e.g. 5 minutes.
3. if we couldn't get the lock immediately, wait until it is released, then go back to step 1.
4. Otherwise, if we *did* obtain the lock immediately, go forth and determine if the make actually exists; if so, screenshot the make. Either way, put information about the result in redis and return either a 404 if the make doesn't exist, or a redirect to the screenshot on S3 if it does.

Tasks left to do:

- [x] Use `REDIS_URL` from environment to connect to redis.
- [x] Update README to mention `REDIS_URL`.
- [ ] Handle redis connection errors?
- [ ] Use some sort of cache eviction strategy, e.g. LRU.
- [ ] Add unit and/or integration tests.
